### PR TITLE
Comment out G wireless line

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -58,7 +58,7 @@ TARGET_SCREEN_HEIGHT := 800
 TARGET_SCREEN_WIDTH := 480
 
 # Wifi related defines
-WIFI_BAND                        := 802_11_ABG
+#WIFI_BAND                        := 802_11_ABG
 WPA_SUPPLICANT_VERSION           := VER_0_8_X
 BOARD_WPA_SUPPLICANT_DRIVER      := NL80211
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_bcmdhd


### PR DESCRIPTION
Hi arco,
Is there any reason to use this line? It limits us to g firmware while our hardware is capable of n. It seem to work this way, at least no drawback, but I can't detect if it is connected with n, the only thing that show difference is a network signal app: 72Mbps instead 54Mbps.
